### PR TITLE
feat(argocd): add props to hide Instance/Server columns 

### DIFF
--- a/workspaces/argocd/.changeset/shy-coins-smile.md
+++ b/workspaces/argocd/.changeset/shy-coins-smile.md
@@ -1,0 +1,19 @@
+---
+'@backstage-community/plugin-argocd': minor
+---
+
+Add `hideInstance` and `hideServer` props to deployment components
+
+Adds optional props to `ArgocdDeploymentSummary` and `ArgocdDeploymentLifecycle` components to allow hiding Instance and Server columns/fields:
+
+- `hideInstance?: boolean` - Hide Instance column/field (default: false)
+- `hideServer?: boolean` - Hide Server column/field (default: false)
+
+**Example usage:**
+
+```tsx
+<ArgocdDeploymentSummary hideInstance hideServer />
+<ArgocdDeploymentLifecycle hideInstance hideServer />
+```
+
+This is useful when you have a single ArgoCD instance and want to declutter the UI by hiding redundant information.

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
@@ -41,6 +41,11 @@ import { ArgoResourcesProvider } from './sidebar/rollouts/RolloutContext';
 import { DrawerProvider } from './DrawerContext';
 import { useTranslation } from '../../hooks/useTranslation';
 
+export interface DeploymentLifecycleProps {
+  hideInstance?: boolean;
+  hideServer?: boolean;
+}
+
 const useDrawerStyles = makeStyles<Theme>(theme =>
   createStyles({
     lifecycle: {
@@ -59,7 +64,10 @@ const useDrawerStyles = makeStyles<Theme>(theme =>
   }),
 );
 
-const DeploymentLifecycle = () => {
+const DeploymentLifecycle = ({
+  hideInstance = false,
+  hideServer = false,
+}: DeploymentLifecycleProps) => {
   const { t } = useTranslation();
   const { entity } = useEntity();
   const classes = useDrawerStyles();
@@ -166,6 +174,8 @@ const DeploymentLifecycle = () => {
             app={app}
             key={app.metadata.uid ?? idx}
             revisions={revisionCache.current}
+            hideInstance={hideInstance}
+            hideServer={hideServer}
             onclick={() => {
               toggleDrawer();
               setActiveItem(app.metadata.uid);
@@ -181,6 +191,8 @@ const DeploymentLifecycle = () => {
           <DeploymentLifecycleDrawer
             isOpen={open}
             onClose={() => setOpen(false)}
+            hideInstance={hideInstance}
+            hideServer={hideServer}
           />
         </ArgoResourcesProvider>
       </DrawerProvider>

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
@@ -56,12 +56,16 @@ interface DeploymentLifecycleCardProps {
   app: Application;
   revisions: RevisionInfo[];
   onclick?: () => void;
+  hideInstance?: boolean;
+  hideServer?: boolean;
 }
 
 const DeploymentLifecycleCard: FC<DeploymentLifecycleCardProps> = ({
   app,
   onclick,
   revisions,
+  hideInstance = false,
+  hideServer = false,
 }) => {
   const appName = app?.metadata?.instance?.name ?? 'default';
   const appHistory = app?.status?.history ?? [];
@@ -93,17 +97,21 @@ const DeploymentLifecycleCard: FC<DeploymentLifecycleCardProps> = ({
 
       <CardContent>
         <Metadata direction={{ sm: 'column' }} gap={{ sm: 'gapMd' }}>
-          <MetadataItem
-            title={t('deploymentLifecycle.deploymentLifecycleCard.instance')}
-          >
-            {appName}
-          </MetadataItem>
+          {!hideInstance && (
+            <MetadataItem
+              title={t('deploymentLifecycle.deploymentLifecycleCard.instance')}
+            >
+              {appName}
+            </MetadataItem>
+          )}
 
-          <MetadataItem
-            title={t('deploymentLifecycle.deploymentLifecycleCard.server')}
-          >
-            <AppServerLink application={app} />
-          </MetadataItem>
+          {!hideServer && (
+            <MetadataItem
+              title={t('deploymentLifecycle.deploymentLifecycleCard.server')}
+            >
+              <AppServerLink application={app} />
+            </MetadataItem>
+          )}
 
           <MetadataItem
             title={t('deploymentLifecycle.deploymentLifecycleCard.namespace')}

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
@@ -45,6 +45,8 @@ import { useTranslation } from '../../hooks/useTranslation';
 interface DeploymentLifecycleDrawerProps {
   isOpen: boolean;
   onClose: () => void;
+  hideInstance?: boolean;
+  hideServer?: boolean;
 }
 
 const useDrawerStyles = makeStyles<Theme>(theme =>
@@ -71,6 +73,8 @@ const useDrawerStyles = makeStyles<Theme>(theme =>
 const DeploymentLifecycleDrawer: FC<DeploymentLifecycleDrawerProps> = ({
   isOpen,
   onClose,
+  hideInstance = false,
+  hideServer = false,
 }) => {
   const {
     application: app,
@@ -125,24 +129,28 @@ const DeploymentLifecycleDrawer: FC<DeploymentLifecycleDrawerProps> = ({
 
           <Grid item xs={12}>
             <Metadata>
-              <MetadataItem
-                title={t(
-                  'deploymentLifecycle.deploymentLifecycleDrawer.instance',
-                )}
-              >
-                {app?.metadata?.instance?.name ??
-                  t(
-                    'deploymentLifecycle.deploymentLifecycleDrawer.instanceDefaultValue',
+              {!hideInstance && (
+                <MetadataItem
+                  title={t(
+                    'deploymentLifecycle.deploymentLifecycleDrawer.instance',
                   )}
-              </MetadataItem>
+                >
+                  {app?.metadata?.instance?.name ??
+                    t(
+                      'deploymentLifecycle.deploymentLifecycleDrawer.instanceDefaultValue',
+                    )}
+                </MetadataItem>
+              )}
 
-              <MetadataItem
-                title={t(
-                  'deploymentLifecycle.deploymentLifecycleDrawer.cluster',
-                )}
-              >
-                <AppServerLink application={app} />
-              </MetadataItem>
+              {!hideServer && (
+                <MetadataItem
+                  title={t(
+                    'deploymentLifecycle.deploymentLifecycleDrawer.cluster',
+                  )}
+                >
+                  <AppServerLink application={app} />
+                </MetadataItem>
+              )}
 
               <MetadataItem
                 title={t(

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleCard.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleCard.test.tsx
@@ -181,3 +181,40 @@ test('application card should not contain commit section for helm based applicat
   const commitLink = screen.queryByText('Commit');
   expect(commitLink).not.toBeInTheDocument();
 });
+
+test('should hide instance when hideInstance prop is true', () => {
+  render(
+    <DeploymentLifecycleCard
+      app={mockApplication}
+      revisions={[]}
+      hideInstance
+    />,
+  );
+
+  expect(screen.queryByText('Instance')).not.toBeInTheDocument();
+  expect(screen.getByText('Server')).toBeInTheDocument();
+});
+
+test('should hide server when hideServer prop is true', () => {
+  render(
+    <DeploymentLifecycleCard app={mockApplication} revisions={[]} hideServer />,
+  );
+
+  expect(screen.getByText('Instance')).toBeInTheDocument();
+  expect(screen.queryByText('Server')).not.toBeInTheDocument();
+});
+
+test('should hide both instance and server when both props are true', () => {
+  render(
+    <DeploymentLifecycleCard
+      app={mockApplication}
+      revisions={[]}
+      hideInstance
+      hideServer
+    />,
+  );
+
+  expect(screen.queryByText('Instance')).not.toBeInTheDocument();
+  expect(screen.queryByText('Server')).not.toBeInTheDocument();
+  expect(screen.getByText('Namespace')).toBeInTheDocument();
+});

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleDrawer.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleDrawer.test.tsx
@@ -222,4 +222,40 @@ describe('DeploymentLifecycleDrawer', () => {
 
     screen.getByText('https://remote-url.com');
   });
+
+  test('should hide instance when hideInstance prop is true', () => {
+    render(
+      <DeploymentLifecycleDrawer isOpen onClose={jest.fn()} hideInstance />,
+      { wrapper },
+    );
+
+    expect(screen.queryByText('Instance')).not.toBeInTheDocument();
+    expect(screen.getByText('Cluster')).toBeInTheDocument();
+  });
+
+  test('should hide cluster when hideServer prop is true', () => {
+    render(
+      <DeploymentLifecycleDrawer isOpen onClose={jest.fn()} hideServer />,
+      { wrapper },
+    );
+
+    expect(screen.getByText('Instance')).toBeInTheDocument();
+    expect(screen.queryByText('Cluster')).not.toBeInTheDocument();
+  });
+
+  test('should hide both instance and cluster when both props are true', () => {
+    render(
+      <DeploymentLifecycleDrawer
+        isOpen
+        onClose={jest.fn()}
+        hideInstance
+        hideServer
+      />,
+      { wrapper },
+    );
+
+    expect(screen.queryByText('Instance')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cluster')).not.toBeInTheDocument();
+    expect(screen.getByText('Namespace')).toBeInTheDocument();
+  });
 });

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -40,7 +40,15 @@ import AppSyncStatus from '../AppStatus/AppSyncStatus';
 import AppHealthStatus from '../AppStatus/AppHealthStatus';
 import { useTranslation } from '../../hooks/useTranslation';
 
-const DeploymentSummary = () => {
+export interface DeploymentSummaryProps {
+  hideInstance?: boolean;
+  hideServer?: boolean;
+}
+
+const DeploymentSummary = ({
+  hideInstance = false,
+  hideServer = false,
+}: DeploymentSummaryProps) => {
   const { entity } = useEntity();
 
   const { baseUrl } = useArgocdConfig();
@@ -202,6 +210,12 @@ const DeploymentSummary = () => {
     },
   ];
 
+  const visibleColumns = columns.filter(col => {
+    if (hideInstance && col.field === 'instance') return false;
+    if (hideServer && col.field === 'server') return false;
+    return true;
+  });
+
   return !error && hasArgocdViewAccess ? (
     <Table
       title={tableTitle}
@@ -213,7 +227,7 @@ const DeploymentSummary = () => {
       }}
       isLoading={loading}
       data={apps}
-      columns={columns}
+      columns={visibleColumns}
     />
   ) : null;
 };

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/__tests__/DeploymentSummary.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/__tests__/DeploymentSummary.test.tsx
@@ -373,4 +373,32 @@ describe('DeploymentSummary', () => {
       expect(within(firstRow).getByText('Degraded')).toBeInTheDocument();
     });
   });
+
+  test('should hide instance column when hideInstance prop is true', async () => {
+    await renderInTestApp(<DeploymentSummary hideInstance />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Instance')).not.toBeInTheDocument();
+      expect(screen.queryByText('Server')).toBeInTheDocument();
+    });
+  });
+
+  test('should hide server column when hideServer prop is true', async () => {
+    await renderInTestApp(<DeploymentSummary hideServer />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Instance')).toBeInTheDocument();
+      expect(screen.queryByText('Server')).not.toBeInTheDocument();
+    });
+  });
+
+  test('should hide both instance and server columns when both props are true', async () => {
+    await renderInTestApp(<DeploymentSummary hideInstance hideServer />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Instance')).not.toBeInTheDocument();
+      expect(screen.queryByText('Server')).not.toBeInTheDocument();
+      expect(screen.queryByText('Namespace')).toBeInTheDocument();
+    });
+  });
 });

--- a/workspaces/argocd/plugins/argocd/src/index.ts
+++ b/workspaces/argocd/plugins/argocd/src/index.ts
@@ -19,3 +19,5 @@ export {
   ArgocdDeploymentSummary,
 } from './plugin';
 export { isArgocdConfigured } from './utils/isArgocdConfigured';
+export type { DeploymentSummaryProps } from './components/DeploymentSummary/DeploymentSummary';
+export type { DeploymentLifecycleProps } from './components/DeploymentLifeCycle/DeploymentLifecycle';


### PR DESCRIPTION
## Summary

  Adds optional `hideInstance` and `hideServer` props to ArgoCD deployment components (`ArgocdDeploymentSummary` and `ArgocdDeploymentLifecycle`) to allow hiding Instance and
  Server columns/fields when they are not needed.

  ## Screenshots

<img width="1167" height="652" alt="deploy-lifecycle-no-filter" src="https://github.com/user-attachments/assets/bbf318e5-d8ce-498f-a938-98f032b1c26d" />
<img width="1397" height="452" alt="deploy-summary-filter" src="https://github.com/user-attachments/assets/3bd9e659-3b7a-4464-96a7-21500e10e6e1" />
<img width="1382" height="487" alt="deploy-summary-no-filter" src="https://github.com/user-attachments/assets/3332538f-5dff-4496-bc16-cd200eb2e0b0" />
<img width="1097" height="542" alt="deploy-lifecycle-filter" src="https://github.com/user-attachments/assets/bc066d68-7acd-44d4-a59e-e0e01af33c4f" />


  ## Changes

  - **DeploymentSummary**: Added props to filter table columns
  - **DeploymentLifecycle**: Props passed through to child components
  - **DeploymentLifecycleCard**: Conditional rendering of Instance/Server metadata items
  - **DeploymentLifecycleDrawer**: Conditional rendering of Instance/Server metadata items
  - **Tests**: Added test coverage for the new props
  - **Type exports**: Exported `DeploymentSummaryProps` and `DeploymentLifecycleProps` interfaces

  ## Usage Example

  ```tsx
  // Hide both Instance and Server columns
  <ArgocdDeploymentSummary hideInstance hideServer />
  <ArgocdDeploymentLifecycle hideInstance hideServer />

  // Hide only Instance
  <ArgocdDeploymentSummary hideInstance />

  // Default behavior (show all)
  <ArgocdDeploymentSummary />

  Use Case

  This is particularly useful when you have a single ArgoCD instance configured. In such cases, the Instance and Server columns show redundant information and can be hidden to
  declutter the UI.

  Backward Compatibility

  ✅ Both props default to false, so existing implementations continue to work without changes.

  Checklist

  - Merge conflicts resolved and combined with new i18n translation features
  - Props interfaces exported from main index
  - Tests added for all components
  - Build successful
  - Lint clean
  - Changeset created
  - All commits have a Signed-off-by line in the message
  - GPG signed commits